### PR TITLE
Fix formatting of subnet extraction in script

### DIFF
--- a/docker-mac-routes-add.sh
+++ b/docker-mac-routes-add.sh
@@ -97,7 +97,7 @@ NETWORKS=$(docker network ls --filter driver=bridge --format "{{.ID}}")
 # Iterate over each network and get its subnet
 for NETWORK_ID in $NETWORKS; do
   # Inspect the network and extract the subnet information
-  SUBNETS=$(docker network inspect --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' "$NETWORK_ID")
+  SUBNETS=$(docker network inspect --format '{{range .IPAM.Config}} {{.Subnet}}{{end}}' "$NETWORK_ID")
 
   # Get the network name for display purposes
   NETWORK_NAME=$(docker network inspect --format '{{.Name}}' "$NETWORK_ID")


### PR DESCRIPTION
Fixes issue where network with multiple subnets had all subnets mashed together into a single string which breaks the `for SUBNET in $SUBNETS` loop.

Before:
```
docker network inspect --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' kind
 fc00:f853:ccd:e793::/64172.18.0.0/16
```

After:
```
docker network inspect --format '{{range .IPAM.Config}} {{.Subnet}}{{end}}' kind
 fc00:f853:ccd:e793::/64 172.18.0.0/16
```